### PR TITLE
doublemetaphone 1.1.0 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: cd185dbc18347accb5a27c1289a6bdc989a479294a74f41c42a6cb0b414e5379
+  # Use upstream archive tarball for tests
+  url: https://github.com/dedupeio/doublemetaphone/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 69eb748a08e8d7d7f4448e8bfbc9b5d5018d979067c9b48c62d121633e4f7b55
 
 build:
-  #skip: true  # [win and py3k]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -28,12 +28,16 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - doublemetaphone
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v tests
 
 about:
   home: https://github.com/datamade/doublemetaphone

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ about:
   home: https://github.com/datamade/doublemetaphone
   license: Artistic-2.0
   license_file: LICENSE
-  license_family: PSF
+  license_family: OTHER
   summary: Python wrapper for C++ Double Metaphone
   description: |
     Python wrapper for Stephen Lacy's C++ Implementation of Double

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,18 @@
 {% set name = "DoubleMetaphone" %}
 {% set version = "1.1" %}
-{% set md5 = "eb6a3f05f3254db7268d462cd0a3ff49" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  md5: {{ md5 }}
+  sha256: cd185dbc18347accb5a27c1289a6bdc989a479294a74f41c42a6cb0b414e5379
 
 build:
-  number: 2
-  script: python setup.py install --single-version-externally-managed --record record.txt
-  skip: true  # [win and py3k]
+  #skip: true  # [win and py3k]
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
@@ -22,21 +20,31 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - python
+    - pip
     - setuptools
+    - wheel
     - cython
-
   run:
     - python
 
 test:
   imports:
     - doublemetaphone
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  license: MIT
-  license_file: LICENSE
-  summary: Python wrapper for C++ Double Metaphone
   home: https://github.com/datamade/doublemetaphone
+  license: Artistic-2.0
+  license_file: LICENSE
+  license_family: PSF
+  summary: Python wrapper for C++ Double Metaphone
+  description: |
+    Python wrapper for Stephen Lacy's C++ Implementation of Double
+    Metaphone. https://github.com/slacy/double-metaphone
+  doc_url: https://github.com/datamade/doublemetaphone
   dev_url: https://github.com/datamade/doublemetaphone
 
 extra:


### PR DESCRIPTION
doublemetaphone 1.1.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4965]
- dev_url:        https://github.com/dedupeio/doublemetaphone/tree/v1.1
- conda_forge:    https://github.com/conda-forge/doublemetaphone-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/doublemetaphone/1.1.0
- pypi inspector: https://inspector.pypi.io/project/doublemetaphone/1.1.0

### Explanation of changes:

- basic build
  - use `sha256` rather than `md5`
  - works on Windows so ignore `skip: true  # [win and py3k]`
  - update to `{{ PYTHON }} -m pip install ...`
  - [!WARNING] Uses Artistic license
    - confirm the `license_family` please!
- add upstream tests (switching to archive tarball)


[PKG-4965]: https://anaconda.atlassian.net/browse/PKG-4965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ